### PR TITLE
make file extension explicit

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -98,7 +98,7 @@ async function lernaAudit(_flags) {
       }
 
       if (!flags['no-report']) {
-        const auditResult = spawnSync('yarn', ['audit', '--json'], {
+        const auditResult = spawnSync('yarn.cmd', ['audit', '--json'], {
           maxBuffer: 10 * 1024 * 1024,
         });
 


### PR DESCRIPTION
Gulp needs it's file extension to be explicit in Windows in order to work in `spawnSync` fn.

Some details can be found e.g. in this thread:
https://github.com/nodejs/node-v0.x-archive/issues/25330#issuecomment-102428996